### PR TITLE
Match Genius paths

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -2,9 +2,8 @@ use crate::genius::{self, GeniusAlbumResponse};
 use crate::settings::{settings_from_req, Settings};
 use crate::utils;
 use actix_web::HttpRequest;
-use actix_web::{get, web, Responder, Result};
+use actix_web::{get, Responder, Result};
 use askama::Template;
-use serde::Deserialize;
 
 use crate::genius::GeniusAlbum;
 use crate::templates::template;
@@ -16,18 +15,11 @@ struct AlbumTemplate {
     album: GeniusAlbum,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct AlbumQuery {
-    path: String,
-}
-
-#[get("/album")]
-pub async fn album(req: HttpRequest, info: web::Query<AlbumQuery>) -> Result<impl Responder> {
-    let album_res = genius::extract_data::<GeniusAlbumResponse>(&utils::ensure_path_prefix(
-        "albums", &info.path,
-    ))
-    .await?;
-    let mut album = album_res.album;
+#[get("/albums/{name:.*}")]
+pub async fn album(req: HttpRequest) -> Result<impl Responder> {
+    let mut album = genius::extract_data::<GeniusAlbumResponse>(req.path())
+        .await?
+        .album;
 
     album.tracks = Some(genius::get_album_tracks(album.id).await?);
 

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -1,10 +1,9 @@
 use crate::settings::{settings_from_req, Settings};
 use crate::utils;
-use actix_web::{get, web, HttpRequest, Responder, Result};
+use actix_web::{get, HttpRequest, Responder, Result};
 use askama::Template;
 use lazy_regex::*;
 use regex::Regex;
-use serde::Deserialize;
 
 use crate::genius::{self, GeniusArtist};
 use crate::genius::{GeniusArtistResponse, SortMode};
@@ -13,7 +12,7 @@ use crate::templates::template;
 static GENIUS_IMAGE_URL: &str = "https://images.genius.com/";
 static GENIUS_BASE_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
 static GENIUS_ALBUMS_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/albums/"#);
-static GENIUS_ARTIST_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/artists/"#);
+static GENIUS_ARTIST_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
 
 #[derive(Template)]
 #[template(path = "artist.html")]
@@ -22,20 +21,13 @@ struct ArtistTemplate {
     artist: GeniusArtist,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ArtistQuery {
-    path: String,
-}
-
 const MAX_SONGS: u8 = 5;
 
-#[get("/artist")]
-pub async fn artist(req: HttpRequest, info: web::Query<ArtistQuery>) -> Result<impl Responder> {
-    let artist_res = genius::extract_data::<GeniusArtistResponse>(&utils::ensure_path_prefix(
-        "artists", &info.path,
-    ))
-    .await?;
-    let mut artist = artist_res.artist;
+#[get("/artists/{name}")]
+pub async fn artist(req: HttpRequest) -> Result<impl Responder> {
+    let mut artist = genius::extract_data::<GeniusArtistResponse>(req.path())
+        .await?
+        .artist;
 
     artist.popular_songs =
         Some(genius::get_artist_songs(artist.id, SortMode::Popularity, MAX_SONGS).await?);
@@ -59,7 +51,7 @@ fn rewrite_links(html: &str) -> String {
         &format!("/api/image?url={}", GENIUS_IMAGE_URL),
     ); // Images
     let html = GENIUS_ALBUMS_PATTERN.replace_all(&html, "/album?path=albums/"); // Albums
-    let html = GENIUS_ARTIST_PATTERN.replace_all(&html, "/artist?path=artists/"); // Artists
+    let html = GENIUS_ARTIST_PATTERN.replace_all(&html, ""); // Artists
     let html = GENIUS_BASE_PATTERN.replace_all(&html, "/lyrics?path=/"); // Lyrics
     html.to_string()
 }

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -11,7 +11,7 @@ use crate::templates::template;
 
 static GENIUS_IMAGE_URL: &str = "https://images.genius.com/";
 static GENIUS_BASE_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
-static GENIUS_ALBUMS_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/albums/"#);
+static GENIUS_ALBUMS_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
 static GENIUS_ARTIST_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
 
 #[derive(Template)]
@@ -50,7 +50,7 @@ fn rewrite_links(html: &str) -> String {
         GENIUS_IMAGE_URL,
         &format!("/api/image?url={}", GENIUS_IMAGE_URL),
     ); // Images
-    let html = GENIUS_ALBUMS_PATTERN.replace_all(&html, "/album?path=albums/"); // Albums
+    let html = GENIUS_ALBUMS_PATTERN.replace_all(&html, ""); // Albums
     let html = GENIUS_ARTIST_PATTERN.replace_all(&html, ""); // Artists
     let html = GENIUS_BASE_PATTERN.replace_all(&html, "/lyrics?path=/"); // Lyrics
     html.to_string()

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -11,8 +11,6 @@ use crate::templates::template;
 
 static GENIUS_IMAGE_URL: &str = "https://images.genius.com/";
 static GENIUS_BASE_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
-static GENIUS_ALBUMS_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
-static GENIUS_ARTIST_PATTERN: Lazy<Regex> = lazy_regex!(r#"https?://\w*.?genius\.com/"#);
 
 #[derive(Template)]
 #[template(path = "artist.html")]
@@ -50,8 +48,6 @@ fn rewrite_links(html: &str) -> String {
         GENIUS_IMAGE_URL,
         &format!("/api/image?url={}", GENIUS_IMAGE_URL),
     ); // Images
-    let html = GENIUS_ALBUMS_PATTERN.replace_all(&html, ""); // Albums
-    let html = GENIUS_ARTIST_PATTERN.replace_all(&html, ""); // Artists
-    let html = GENIUS_BASE_PATTERN.replace_all(&html, "/lyrics?path=/"); // Lyrics
+    let html = GENIUS_BASE_PATTERN.replace_all(&html, ""); // We follow Genius' schema
     html.to_string()
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -3,7 +3,7 @@ use include_dir::{include_dir, Dir};
 
 const STATIC_RESOURCES: Dir = include_dir!("$CARGO_MANIFEST_DIR/static");
 
-#[get("{resource}")]
+#[get("{resource}.{ext}")]
 pub async fn resource(path: web::Path<String>) -> impl Responder {
     asset(path.as_str())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,12 +16,3 @@ pub fn borrowed_u8_eq(a: &u8, b: &u8) -> bool {
 pub fn path_from_url(url: &str) -> String {
     url.splitn(4, '/').last().unwrap().to_owned()
 }
-
-pub fn ensure_path_prefix(prefix: &'static str, path: &str) -> String {
-    let path = path.trim_start_matches('/');
-    if path.starts_with(prefix) {
-        path.to_string()
-    } else {
-        format!("{}/{}", prefix, path)
-    }
-}

--- a/templates/album.html
+++ b/templates/album.html
@@ -19,7 +19,7 @@
         <div class="song-info">
             <p class="title">{{ album.name|e }}</p>
             <p class="artist-name">By 
-                <a href="artist?path={{ utils::path_from_url(album.artist.url)|urlencode }}">
+                <a href="/{{ utils::path_from_url(album.artist.url)|urlencode }}">
                     <cite>{{ album.artist.name|e }}</cite>
                 </a>
             </p>

--- a/templates/album.html
+++ b/templates/album.html
@@ -29,7 +29,7 @@
                 <p class="stats-release-date">Released on {{ album.release_date_for_display.as_ref().unwrap()|e }}</p>
             {% endif %}
         </div>
-        <img class="header-cover" src="api/image?url={{ album.cover_art_url|urlencode }}&size=500" alt="Thumbnail"/>
+        <img class="header-cover" src="/api/image?url={{ album.cover_art_url|urlencode }}&size=500" alt="Thumbnail"/>
     </div>
     <br/>
     {% if album.tracks.is_some() %}

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -31,7 +31,7 @@
     <div class="artist-socials">
         {% for social in artist.socials() %}
             <a class="social {{social.brand|e}}" href="https://{{social.brand}}.com/{{social.name_raw|urlencode}}">
-                <img class="social-icon" src="icon/{{social.brand}}.svg"/>
+                <img class="social-icon" src="/icon/{{social.brand}}.svg"/>
                 <p class="social-name">{{ social.name_formatted|e }}</p>
             </a>
         {% endfor %}
@@ -46,7 +46,7 @@
             {% for song in artist.popular_songs.as_ref().unwrap() %}
                 {% include "song.html" %}
             {% endfor %}
-            <a class="artist-search-songs text-centered" href="search?q={{ artist.name|urlencode }}">Search for songs</a>
+            <a class="artist-search-songs text-centered" href="/search?q={{ artist.name|urlencode }}">Search for songs</a>
         </div>
     {% endif %}
 </div>

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -16,7 +16,7 @@
 
 {% block content %}
 <div class="artist">
-    <img class="artist-image" src="api/image?url={{ artist.image_url|urlencode }}&size=500" alt="Thumbnail"/>
+    <img class="artist-image" src="/api/image?url={{ artist.image_url|urlencode }}&size=500" alt="Thumbnail"/>
     <div class="artist-info">
         <p class="artist-name">{{ artist.name|e }}</p>
         {% if artist.alternate_names.is_some() && !artist.alternate_names.as_ref().unwrap().is_empty() %}

--- a/templates/lyrics.html
+++ b/templates/lyrics.html
@@ -22,7 +22,7 @@
             </p>
             {% if song.album.is_some() %}
                 <p class="album-name">On
-                    <a href="album?path={{ utils::path_from_url(song.album.as_ref().unwrap().url)|urlencode }}">
+                    <a href="/{{ utils::path_from_url(song.album.as_ref().unwrap().url)|urlencode }}">
                         <cite>{{ song.album.as_ref().unwrap().name|e }}</cite>
                     </a>
                 </p>

--- a/templates/lyrics.html
+++ b/templates/lyrics.html
@@ -16,7 +16,7 @@
         <div class="song-info">
             <p class="title">{{ song.title|e }}</p>
             <p class="artist-name">By 
-                <a href="artist?path={{ utils::path_from_url(song.primary_artist.url)|urlencode }}">
+                <a href="/{{ utils::path_from_url(song.primary_artist.url)|urlencode }}">
                     <cite>{{ song.primary_artist.name|e }}</cite>
                 </a>
             </p>

--- a/templates/lyrics.html
+++ b/templates/lyrics.html
@@ -36,7 +36,7 @@
                 <p class="stats-views">{{ utils::pretty_format_num(song.stats.pageviews.unwrap())|e }} Views</p>
             {% endif %}
         </div>
-        <img class="header-cover" src="api/image?url={{ song.header_image_url|urlencode }}&size=500" alt="Thumbnail"/>
+        <img class="header-cover" src="/api/image?url={{ song.header_image_url|urlencode }}&size=500" alt="Thumbnail"/>
     </div>
     <br/>
     {% for verse in verses %}

--- a/templates/lyrics.html
+++ b/templates/lyrics.html
@@ -6,7 +6,7 @@
 
 {% block navright %}
 <div class="nav-item.right">
-    <a class="external-link" href="https://genius.com{{ query.path|urlencode }}">View on Genius</a>
+    <a class="external-link" href="https://genius.com{{ path|urlencode }}">View on Genius</a>
 </div>
 {% endblock %}
 

--- a/templates/song.html
+++ b/templates/song.html
@@ -1,4 +1,4 @@
-<a class="song" href="lyrics?path={{ song.path|urlencode }}&id={{ song.id|urlencode }}">
+<a class="song" href="{{ song.path|urlencode }}?id={{ song.id|urlencode }}">
     <img class="song-thumbnail" 
         src="/api/image?url={{ song.song_art_image_thumbnail_url|urlencode }}&size=150"
         alt="Thumbnail"

--- a/templates/song.html
+++ b/templates/song.html
@@ -1,6 +1,6 @@
 <a class="song" href="lyrics?path={{ song.path|urlencode }}&id={{ song.id|urlencode }}">
     <img class="song-thumbnail" 
-        src="api/image?url={{ song.song_art_image_thumbnail_url|urlencode }}&size=150"
+        src="/api/image?url={{ song.song_art_image_thumbnail_url|urlencode }}&size=150"
         alt="Thumbnail"
     />
     <h2 class="song-title">{{ song.title|e }}</h2>


### PR DESCRIPTION
Currently, we have our own schema for paths, with Genius paths being passed in query parameters. This makes it complicated to set automatic redirects from Genius to Intellectual and adds unnecessary complexity to the code.

This will need some testing to ensure that there are no edge cases that break the links and that no links were missed.
~~We also need a way to return a proper 404 page, since the lyric pattern now matches all paths. We might be able to only match paths that end in `-lyrics`, or we'll have to bail and return our own 404 if genius returns a 404.~~

We should also try to coordinate the release of this with LibRedirect to minimize the damage from this.