### PR TITLE
Changed the `max-width` property to `50%` for images in annotations and centered them

### DIFF
--- a/static/style/lyrics.css
+++ b/static/style/lyrics.css
@@ -162,8 +162,10 @@ html:has(.annotation:target) {
 
 .annotation__content img {
     border-radius: var(--radius);
-    max-width: 100%;
+    max-width: 50%;
     height: auto;
+    display: block;
+    margin: auto;
 }
 
 .annotation__header {


### PR DESCRIPTION
<img width="900" height="463" alt="image" src="https://github.com/user-attachments/assets/fcf8d1e9-c6a0-4646-ad1f-e496f0932c98" />

<img width="1200" height="554" alt="image" src="https://github.com/user-attachments/assets/87bd76ea-3335-4fff-b320-3efa24d883df" />

I reduced the max width and centered the image because it didn't fit completely and was inconvenient.

URL from photo: https://int.dc09.xyz/Slava-kpss-dc-freestyle-lyrics?id=12329195#annotation-37756259